### PR TITLE
fixed upload files

### DIFF
--- a/perplexity/client.py
+++ b/perplexity/client.py
@@ -113,7 +113,7 @@ class Client:
         
         for filename, file in files.items():
             file_type = mimetypes.guess_type(filename)[0]
-            file_upload_info = (await self.session.post(
+            file_upload_info = (self.session.post(
                 'https://www.perplexity.ai/rest/uploads/create_upload_url?version=2.18&source=default',
                 json={
                     'content_type': file_type,
@@ -129,12 +129,12 @@ class Client:
                 mp.addpart(name=key, data=value)
             mp.addpart(name='file', content_type=file_type, filename=filename, data=file)
 
-            upload_resp = await self.session.post(file_upload_info['s3_bucket_url'], multipart=mp)
+            upload_resp = self.session.post(file_upload_info['s3_bucket_url'], multipart=mp)
             
             if not upload_resp.ok:
                 raise Exception('File upload error', upload_resp)
 
-            if 'image/upload' in file_upload_info['s3_bucket_url']:
+            if 'image/upload' in file_upload_info['s3_object_url']:
                 uploaded_url = re.sub(
                     r'/private/s--.*?--/v\d+/user_uploads/',
                     '/private/user_uploads/',

--- a/perplexity/client.py
+++ b/perplexity/client.py
@@ -112,27 +112,38 @@ class Client:
         uploaded_files = []
         
         for filename, file in files.items():
-            file_upload_info = self.session.post('https://www.perplexity.ai/rest/uploads/create_upload_url?version=2.18&source=default', json={
-                'content_type': mimetypes.guess_type(filename)[0],
-                'file_size': sys.getsizeof(file),
-                'filename': filename,
-                'force_image': False,
-                'source': 'default',
-            }).json()
-            
+            file_type = mimetypes.guess_type(filename)[0]
+            file_upload_info = (await self.session.post(
+                'https://www.perplexity.ai/rest/uploads/create_upload_url?version=2.18&source=default',
+                json={
+                    'content_type': file_type,
+                    'file_size': sys.getsizeof(file),
+                    'filename': filename,
+                    'force_image': False,
+                    'source': 'default',
+                }
+            )).json()
+
             mp = CurlMime()
-            
             for key, value in file_upload_info['fields'].items():
                 mp.addpart(name=key, data=value)
-            
-            mp.addpart(name='file', content_type=mimetypes.guess_type(filename)[0], filename=filename, data=file)
-            
-            upload_resp = self.session.post(file_upload_info['s3_bucket_url'], multipart=mp)
+            mp.addpart(name='file', content_type=file_type, filename=filename, data=file)
+
+            upload_resp = await self.session.post(file_upload_info['s3_bucket_url'], multipart=mp)
             
             if not upload_resp.ok:
                 raise Exception('File upload error', upload_resp)
-            
-            uploaded_files.append(upload_resp.json()['secure_url'])
+
+            if 'image/upload' in file_upload_info['s3_bucket_url']:
+                uploaded_url = re.sub(
+                    r'/private/s--.*?--/v\d+/user_uploads/',
+                    '/private/user_uploads/',
+                    upload_resp.json()['secure_url']
+                )
+            else:
+                uploaded_url = file_upload_info['s3_object_url']
+
+            uploaded_files.append(uploaded_url)
         
         json_data = {
             'query_str': query,


### PR DESCRIPTION
could not uploads any files:

if the file was not an image - did not get secure_url, because the upload_resp request returned nothing and you need to use s3_object_url. 

But for an image secure_url is returned: if the file is an image, you need to send a request to s3_bucket_url with all the necessary data, then from upload_resp we get secure_url and remove unnecessary data, then use the link for attachment.  