### PR TITLE
fix: MCP tools always return empty string (no top-level answer key)

### DIFF
--- a/perplexity/mcp.py
+++ b/perplexity/mcp.py
@@ -16,6 +16,15 @@ mcp = FastMCP(
 )
 
 
+def _extract_answer(resp: dict) -> str:
+    # search() responses have no top-level "answer" key — the text lives in
+    # the ask_text block's markdown_block.answer.
+    for block in resp.get("blocks", []):
+        if block.get("intended_usage") == "ask_text":
+            return block.get("markdown_block", {}).get("answer", "")
+    return resp.get("answer", "")
+
+
 def perplexity_ask(query: str) -> str:
     """Ask Perplexity a question and get a concise AI-generated answer.
 
@@ -28,7 +37,7 @@ def perplexity_ask(query: str) -> str:
     - Returns plain text only (no citations, images, or structured results).
     - Answers may not reflect the very latest real-time information.
     """
-    return client.search(query, mode="auto").get("answer", "")
+    return _extract_answer(client.search(query, mode="auto"))
 
 
 def perplexity_research(query: str) -> str:
@@ -44,7 +53,7 @@ def perplexity_research(query: str) -> str:
     - Returns plain text only (no citations, images, or structured results).
     - Only one model is available in this mode (cannot select a specific model).
     """
-    return client.search(query, mode="deep research").get("answer", "")
+    return _extract_answer(client.search(query, mode="deep research"))
 
 
 def perplexity_reason(query: str) -> str:
@@ -59,7 +68,7 @@ def perplexity_reason(query: str) -> str:
     - Does not support follow-up context, file uploads, or source filtering.
     - Returns plain text only (no citations, images, or structured results).
     """
-    return client.search(query, mode="reasoning").get("answer", "")
+    return _extract_answer(client.search(query, mode="reasoning"))
 
 
 def perplexity_search(query: str) -> str:
@@ -74,7 +83,7 @@ def perplexity_search(query: str) -> str:
     - Does not support follow-up context or file uploads.
     - Returns plain text only (no citations, images, or structured results).
     """
-    return client.search(query, mode="pro", sources=["web"]).get("answer", "")
+    return _extract_answer(client.search(query, mode="pro", sources=["web"]))
 
 
 def main():


### PR DESCRIPTION
## Summary
- All four MCP tools (`perplexity_ask`, `perplexity_research`, `perplexity_reason`, `perplexity_search`) call `.get("answer", "")` on the top-level `client.search()` response, but that dict has no top-level `"answer"` key — the text lives at `blocks[N].markdown_block.answer` for the block where `intended_usage == "ask_text"`.
- Result: every MCP tool call returns `""`, regardless of query, mode, or auth/cookie state.
- Added `_extract_answer()` which walks `blocks` for the `ask_text` block and pulls the answer from `markdown_block.answer`, falling back to the old top-level lookup for safety.

## Repro
```python
import perplexity
client = perplexity.Client()
resp = client.search("What is 2+2?")
resp.get("answer", "")   # -> "" (the bug)
resp["blocks"][0]["markdown_block"]["answer"]   # -> "2+2 equals 4...."
```

## Test plan
- [x] Verified `_extract_answer()` returns the correct text against a live anonymous `search()` call
- [x] Confirmed the bug reproduces identically with and without `PERPLEXITY_COOKIES` set (auth state is irrelevant — purely a response-parsing bug)