### PR TITLE
fix(mcp): route logging to stderr and use an absolute XDG state path for the log file

### DIFF
--- a/perplexity/config.py
+++ b/perplexity/config.py
@@ -5,6 +5,8 @@ This module contains all configurable constants used throughout the library.
 Modify these values to customize behavior without changing core code.
 """
 
+import os
+from pathlib import Path
 from typing import Dict
 
 # API Configuration
@@ -123,7 +125,11 @@ RETRY_EXCEPTIONS = (ConnectionError, TimeoutError)
 # Logging Configuration
 LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 LOG_LEVEL = "INFO"
-LOG_FILE = "perplexity.log"
+# Default log path lives under the XDG state dir so the stdio MCP server never
+# writes into the client's (often read-only or unrelated) working directory.
+# An explicit LOG_FILE / logger parameter still overrides this default.
+_STATE_HOME = os.environ.get("XDG_STATE_HOME") or str(Path.home() / ".local" / "state")
+LOG_FILE = str(Path(_STATE_HOME) / "perplexity-ai" / "perplexity.log")
 
 # Rate Limiting
 RATE_LIMIT_MIN_DELAY = 1.0  # seconds

--- a/perplexity/logger.py
+++ b/perplexity/logger.py
@@ -46,7 +46,10 @@ def setup_logger(
 
     # Console handler
     if console:
-        console_handler = logging.StreamHandler(sys.stdout)
+        # Log to stderr, not stdout: for stdio MCP transports stdout is the
+        # JSON-RPC protocol channel, and any log line there corrupts it
+        # (server shows as failed in strict clients like Claude Desktop).
+        console_handler = logging.StreamHandler(sys.stderr)
         console_handler.setFormatter(formatter)
         logger.addHandler(console_handler)
 


### PR DESCRIPTION
### Problem

When `perplexity-mcp` runs as a stdio MCP server, two logging behaviours break real clients:

1. **stdout corruption** — the console log handler writes to `sys.stdout`. For stdio MCP transports, stdout is the JSON-RPC protocol channel, so any non-JSON-RPC line corrupts the stream. Strict clients (e.g. Claude Desktop) then show the server as failed, even though a terminal smoke test looks fine — the classic "terminal-green, client-red" trap.
2. **Relative log file path** — `LOG_FILE = "perplexity.log"` (`perplexity/config.py`) is resolved against the client's working directory. MCP clients spawn servers with an arbitrary cwd (often `/`), so the server either litters unrelated directories with log files or fails on a read-only cwd.

### Fix

1. `perplexity/logger.py`: the console handler logs to `sys.stderr`.
2. `perplexity/config.py`: the default log path goes to the XDG state directory — `$XDG_STATE_HOME/perplexity-ai/perplexity.log`, falling back to `~/.local/state/perplexity-ai/perplexity.log` when `XDG_STATE_HOME` is unset. An explicit `LOG_FILE` / `setup_logger(log_file=...)` still overrides.

### Verification

- `initialize` handshake over stdio: stdout contains only JSON-RPC responses; all log lines (including the "Authenticated — all 4 tools available" message) appear on stderr; exit 0.
- Server starts from a read-only cwd without writing into it.

Small, backwards-compatible change (explicit overrides are respected). Happy to adjust naming/paths to your preference.
