### PR TITLE
fix(mcp): support mcp SDK 2.x (fastmcp → mcpserver rename)

### DIFF
--- a/perplexity/mcp.py
+++ b/perplexity/mcp.py
@@ -2,18 +2,30 @@ import json
 import os
 import sys
 
-from mcp.server.fastmcp import FastMCP
+try:
+    # mcp >= 2.0 renamed mcp.server.fastmcp.FastMCP to
+    # mcp.server.mcpserver.MCPServer and moved host/port from the
+    # constructor to run().
+    from mcp.server.mcpserver import MCPServer as _Server
+
+    _HTTP_BIND_ON_RUN = True
+except ImportError:  # mcp 1.x
+    from mcp.server.fastmcp import FastMCP as _Server
+
+    _HTTP_BIND_ON_RUN = False
 
 from perplexity import Client
 from perplexity.logger import setup_logger
 
 logger = setup_logger("mcp")
 
-mcp = FastMCP(
-    "perplexity",
-    host=os.environ.get("MCP_HOST", "127.0.0.1"),
-    port=int(os.environ.get("MCP_PORT", "8000")),
-)
+HOST = os.environ.get("MCP_HOST", "127.0.0.1")
+PORT = int(os.environ.get("MCP_PORT", "8000"))
+
+if _HTTP_BIND_ON_RUN:
+    mcp = _Server("perplexity")
+else:
+    mcp = _Server("perplexity", host=HOST, port=PORT)
 
 
 def _extract_answer(resp: dict) -> str:
@@ -120,6 +132,8 @@ def main():
 
     if transport == "stdio":
         mcp.run()
+    elif _HTTP_BIND_ON_RUN:
+        mcp.run(transport="streamable-http", host=HOST, port=PORT)
     else:
         mcp.run(transport="streamable-http")
 


### PR DESCRIPTION
## Problem

`mcp` 2.0.0 removed `mcp.server.fastmcp`. The module was renamed to `mcp.server.mcpserver` and `FastMCP` to `MCPServer`.

The `[mcp]` extra declares an unpinned `mcp>=1.0.0`, so every fresh install now resolves 2.x and the server dies at import, before it can serve anything:

```
Traceback (most recent call last):
  File ".../bin/perplexity-mcp", line 6, in <module>
    from perplexity.mcp import main
  File ".../perplexity/mcp.py", line 5, in <module>
    from mcp.server.fastmcp import FastMCP
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

Reproduce:

```bash
uvx --from "perplexity-api[mcp] @ git+https://github.com/helallao/perplexity-ai" perplexity-mcp
```

This hits anyone installing via `uvx`/`pipx` or into a fresh venv. Existing environments with a cached 1.x resolution keep working, which makes it look intermittent — clients typically surface it as a connection timeout rather than the traceback.

## Fix

Import whichever class the installed SDK provides, so both 1.x and 2.x work and no upper pin is needed.

One wrinkle beyond the rename: `MCPServer.__init__` no longer accepts `host`/`port` (they moved to `run()`, and there is no `**kwargs`), so a plain import alias would raise `TypeError` on startup. Those are passed at the call site on 2.x; the 1.x path is untouched.

## Testing

Against `mcp` 1.29.0 and 2.0.0:

| SDK | stdio: `initialize` + `tools/list` | `MCP_TRANSPORT=http` |
|-----|-----------------------------------|----------------------|
| 1.29.0 | ✅ all 4 tools | ✅ binds, `POST /mcp` → 200 |
| 2.0.0 | ✅ all 4 tools | ✅ binds, `POST /mcp` → 200 |

Both authenticated (`PERPLEXITY_COOKIES` set) and anonymous paths exercised. `black --check` clean.

## Note

Under 2.x, `serverInfo.version` comes back empty, where 1.x auto-filled it with the SDK's own version. Cosmetic and pre-existing in the sense that neither reported the *package* version, so I left it alone rather than widen this PR — happy to set it explicitly if you'd prefer.